### PR TITLE
リファレンス反映ができているかの検証

### DIFF
--- a/src/main/java/com/nifcloud/mbaas/core/NCMBInstallation.kt
+++ b/src/main/java/com/nifcloud/mbaas/core/NCMBInstallation.kt
@@ -27,7 +27,6 @@ import java.util.*
 
 /**
  * Installation information handle class
- * 【テスト書き換え】
  *
  * NCMBInstallation is used to retrieve and save, update the installation data.
  * Basic features are inherit from NCMBObject and NCMBBase


### PR DESCRIPTION
前回までの検証でリファレンスのNCMBInstallationの説明に「テスト書き換え」という単語が含まれているので削除。
これがなくなったリファレンスがデプロイされるか確認。